### PR TITLE
Show per-partition log sizes rather than per topic

### DIFF
--- a/rhosak.json
+++ b/rhosak.json
@@ -1065,34 +1065,7 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
-        "definition": "",
-        "description": null,
-        "error": null,
-        "hide": 0,
-        "includeAll": false,
-        "label": "Namespace",
-        "multi": false,
-        "name": "kubernetes_namespace",
-        "options": [],
-        "query": {
-          "query": "query_result(kafka_server_replicamanager_leadercount)",
-          "refId": "Prometheus-kubernetes_namespace-Variable-Query"
-        },
-        "refresh": 1,
-        "regex": "/.*namespace=\"([^\"]*).*/",
-        "skipUrlSync": false,
-        "sort": 0,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      },
-      {
-        "allValue": null,
-        "current": {},
-        "datasource": "${DS_PROMETHEUS}",
-        "definition": "",
+        "definition": "kafka_instance_connection_limit",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1102,11 +1075,11 @@
         "name": "strimzi_cluster_name",
         "options": [],
         "query": {
-          "query": "query_result(kafka_server_replicamanager_leadercount{namespace=\"$kubernetes_namespace\"})",
-          "refId": "Prometheus-strimzi_cluster_name-Variable-Query"
+          "query": "kafka_instance_connection_limit",
+          "refId": "StandardVariableQuery"
         },
         "refresh": 1,
-        "regex": "/.*strimzi_io_cluster=\"([^\"]*).*/",
+        "regex": "/.*instance_name=\"([^\"]*).*/",
         "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
@@ -1119,7 +1092,7 @@
         "allValue": ".*",
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
-        "definition": "",
+        "definition": "kafka_instance_connection_limit{instance_name=\"$strimzi_cluster_name\"}",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1129,11 +1102,11 @@
         "name": "kafka_broker",
         "options": [],
         "query": {
-          "query": "query_result(kafka_server_replicamanager_leadercount{namespace=\"$kubernetes_namespace\",strimzi_io_cluster=\"$strimzi_cluster_name\"})",
-          "refId": "Prometheus-kafka_broker-Variable-Query"
+          "query": "kafka_instance_connection_limit{instance_name=\"$strimzi_cluster_name\"}",
+          "refId": "StandardVariableQuery"
         },
         "refresh": 1,
-        "regex": "/.*pod_name=\"$strimzi_cluster_name-([^\"]*).*/",
+        "regex": "/.*broker_id=\"([^\"]*).*/",
         "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
@@ -1146,7 +1119,7 @@
         "allValue": ".+",
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
-        "definition": "",
+        "definition": "kas_topic_partition_log_size_bytes{strimzi_io_cluster=~\"$strimzi_cluster_name\",broker_id=\"$kafka_broker\"}",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1156,11 +1129,11 @@
         "name": "kafka_topic",
         "options": [],
         "query": {
-          "query": "query_result(kafka_cluster_partition_replicascount{namespace=\"$kubernetes_namespace\",strimzi_io_cluster=\"$strimzi_cluster_name\",kubernetes_pod_name=~\"$strimzi_cluster_name-$kafka_broker\"})",
-          "refId": "Prometheus-kafka_topic-Variable-Query"
+          "query": "kas_topic_partition_log_size_bytes{strimzi_io_cluster=~\"$strimzi_cluster_name\",broker_id=\"$kafka_broker\"}",
+          "refId": "StandardVariableQuery"
         },
         "refresh": 1,
-        "regex": "/.*topic=\"([^\"]*).*/",
+        "regex": "/.*topic_name=\"([^\"]*).*/",
         "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
@@ -1173,7 +1146,7 @@
         "allValue": ".*",
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
-        "definition": "",
+        "definition": "kas_topic_partition_log_size_bytes{strimzi_io_cluster=~\"$strimzi_cluster_name\",broker_id=\"$kafka_broker\",topic_name=\"$kafka_topic\"}",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1183,11 +1156,11 @@
         "name": "kafka_partition",
         "options": [],
         "query": {
-          "query": "query_result(kafka_log_log_size{namespace=\"$kubernetes_namespace\",strimzi_io_cluster=\"$strimzi_cluster_name\",kubernetes_pod_name=~\"$strimzi_cluster_name-$kafka_broker\",topic=~\"$kafka_topic\"})",
-          "refId": "Prometheus-kafka_partition-Variable-Query"
+          "query": "kas_topic_partition_log_size_bytes{strimzi_io_cluster=~\"$strimzi_cluster_name\",broker_id=\"$kafka_broker\",topic_name=\"$kafka_topic\"}",
+          "refId": "StandardVariableQuery"
         },
         "refresh": 1,
-        "regex": "/.*partition=\"([^\"]*).*/",
+        "regex": "/.*partition_id=\"([^\"]*).*/",
         "skipUrlSync": false,
         "sort": 3,
         "tagValuesQuery": "",

--- a/rhosak.json
+++ b/rhosak.json
@@ -52,7 +52,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1678737515310,
+  "iteration": 1678738842660,
   "links": [],
   "panels": [
     {
@@ -614,7 +614,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "${DS_PROMETHEUS}",
-      "description": "Kafka broker pods disk usage",
+      "description": "Kafka broker available space per disk.\n\nLegend label format: data-<disk>-<cluster name>-kafka-<broker ID>",
       "fieldConfig": {
         "defaults": {},
         "overrides": []
@@ -711,7 +711,7 @@
     {
       "cacheTimeout": null,
       "datasource": "${DS_PROMETHEUS}",
-      "description": "Total partitions offline",
+      "description": "Total partitions",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -838,7 +838,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "kas_topic_partition_log_size_bytes{strimzi_io_cluster=~\"$strimzi_cluster_name\",broker_id=\"$kafka_broker\",topic_name=~\"$kafka_topic\",partition_id=~\"$kafka_partition\"}",
+          "expr": "kas_topic_partition_log_size_bytes{strimzi_io_cluster=~\"$strimzi_cluster_name\",broker_id=~\"$kafka_broker\",topic_name=~\"$kafka_topic\",partition_id=~\"$kafka_partition\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -1008,7 +1008,7 @@
     "list": [
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "Prometheus",
           "value": "Prometheus"
         },

--- a/rhosak.json
+++ b/rhosak.json
@@ -674,7 +674,7 @@
       "title": "Available Disk Space",
       "tooltip": {
         "shared": true,
-        "sort": 0,
+        "sort": 2,
         "value_type": "individual"
       },
       "type": "graph",
@@ -802,7 +802,7 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 7,
+        "h": 9,
         "w": 12,
         "x": 12,
         "y": 17
@@ -810,13 +810,19 @@
       "hiddenSeries": false,
       "id": 91,
       "legend": {
+        "alignAsTable": true,
         "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
+        "current": true,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": true,
+        "min": true,
+        "rightSide": false,
         "show": true,
+        "sort": "current",
+        "sortDesc": true,
         "total": false,
-        "values": false
+        "values": true
       },
       "lines": true,
       "linewidth": 1,
@@ -843,7 +849,7 @@
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{topic_name}}:{{partition_id}}",
+          "legendFormat": "broker {{broker_id}}, topic {{topic_name}}, partition {{partition_id}}",
           "refId": "A"
         }
       ],
@@ -854,9 +860,10 @@
       "title": "Log Size",
       "tooltip": {
         "shared": true,
-        "sort": 0,
+        "sort": 2,
         "value_type": "individual"
       },
+      "transformations": [],
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -912,6 +919,8 @@
       "legend": {
         "avg": false,
         "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
         "max": false,
         "min": false,
         "show": true,
@@ -943,16 +952,16 @@
           "hide": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "used {{persistentvolumeclaim}}",
-          "refId": "A"
+          "legendFormat": "Used: {{persistentvolumeclaim}}",
+          "refId": "Used"
         },
         {
           "exemplar": true,
           "expr": "kafka_broker_quota_softlimitbytes{statefulset_kubernetes_io_pod_name=~\"$strimzi_cluster_name-kafka-$kafka_broker\"}",
           "hide": false,
           "interval": "",
-          "legendFormat": "Limit {{statefulset_kubernetes_io_pod_name}}",
-          "refId": "B"
+          "legendFormat": "Limit: {{statefulset_kubernetes_io_pod_name}}",
+          "refId": "Limit"
         }
       ],
       "thresholds": [],
@@ -962,9 +971,10 @@
       "title": "Used Disk Space",
       "tooltip": {
         "shared": true,
-        "sort": 0,
+        "sort": 2,
         "value_type": "individual"
       },
+      "transformations": [],
       "type": "graph",
       "xaxis": {
         "buckets": null,

--- a/rhosak.json
+++ b/rhosak.json
@@ -104,7 +104,7 @@
               }
             ]
           },
-          "unit": "Bps"
+          "unit": "binBps"
         },
         "overrides": []
       },
@@ -185,7 +185,7 @@
               }
             ]
           },
-          "unit": "Bps"
+          "unit": "binBps"
         },
         "overrides": []
       },
@@ -333,7 +333,7 @@
     {
       "cacheTimeout": null,
       "datasource": "${DS_PROMETHEUS}",
-      "description": "Incoming messages rate",
+      "description": "Incoming message rate",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -365,7 +365,7 @@
               }
             ]
           },
-          "unit": "wps"
+          "unit": "msg/s"
         },
         "overrides": []
       },
@@ -408,7 +408,7 @@
           "refId": "A"
         }
       ],
-      "title": "Incoming Messages Rate",
+      "title": "Incoming Message Rate",
       "type": "stat"
     },
     {

--- a/rhosak.json
+++ b/rhosak.json
@@ -1085,7 +1085,7 @@
         "allValue": ".+",
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
-        "definition": "kas_topic_partition_log_size_bytes{strimzi_io_cluster=~\"$strimzi_cluster_name\",broker_id=\"$kafka_broker\"}",
+        "definition": "kas_topic_partition_log_size_bytes{strimzi_io_cluster=~\"$strimzi_cluster_name\",broker_id=~\"$kafka_broker\"}",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1095,7 +1095,7 @@
         "name": "kafka_topic",
         "options": [],
         "query": {
-          "query": "kas_topic_partition_log_size_bytes{strimzi_io_cluster=~\"$strimzi_cluster_name\",broker_id=\"$kafka_broker\"}",
+          "query": "kas_topic_partition_log_size_bytes{strimzi_io_cluster=~\"$strimzi_cluster_name\",broker_id=~\"$kafka_broker\"}",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
@@ -1112,7 +1112,7 @@
         "allValue": ".*",
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
-        "definition": "kas_topic_partition_log_size_bytes{strimzi_io_cluster=~\"$strimzi_cluster_name\",broker_id=\"$kafka_broker\",topic_name=\"$kafka_topic\"}",
+        "definition": "kas_topic_partition_log_size_bytes{strimzi_io_cluster=~\"$strimzi_cluster_name\",broker_id=~\"$kafka_broker\",topic_name=~\"$kafka_topic\"}",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1122,7 +1122,7 @@
         "name": "kafka_partition",
         "options": [],
         "query": {
-          "query": "kas_topic_partition_log_size_bytes{strimzi_io_cluster=~\"$strimzi_cluster_name\",broker_id=\"$kafka_broker\",topic_name=\"$kafka_topic\"}",
+          "query": "kas_topic_partition_log_size_bytes{strimzi_io_cluster=~\"$strimzi_cluster_name\",broker_id=~\"$kafka_broker\",topic_name=~\"$kafka_topic\"}",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/rhosak.json
+++ b/rhosak.json
@@ -52,7 +52,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1678738842660,
+  "iteration": 1678801740770,
   "links": [],
   "panels": [
     {
@@ -433,16 +433,12 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "#d44a3a",
+                "color": "semi-dark-green",
                 "value": null
               },
               {
-                "color": "rgba(237, 129, 40, 0.89)",
-                "value": 0
-              },
-              {
-                "color": "#299c46",
-                "value": 2
+                "color": "semi-dark-red",
+                "value": 1
               }
             ]
           },
@@ -1018,7 +1014,7 @@
     "list": [
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": "Prometheus",
           "value": "Prometheus"
         },

--- a/rhosak.json
+++ b/rhosak.json
@@ -137,7 +137,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(irate(kafka_server_brokertopicmetrics_bytes_in_total{topic=~\"$kafka_topic\",topic!=\"\",statefulset_kubernetes_io_pod_name=~\"$kafka_broker-kafka-[0-9]+\"}[1m]))",
+          "expr": "sum(irate(kafka_server_brokertopicmetrics_bytes_in_total{topic=~\"$kafka_topic\",topic!=\"\",statefulset_kubernetes_io_pod_name=~\"$strimzi_cluster_name-kafka-$kafka_broker\"}[1m]))",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -227,7 +227,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(irate(kafka_server_brokertopicmetrics_bytes_out_total{topic=~\"$kafka_topic\",topic!=\"\",statefulset_kubernetes_io_pod_name=~\"$kafka_broker-kafka-[0-9]+\"}[1m]))",
+          "expr": "sum(irate(kafka_server_brokertopicmetrics_bytes_out_total{topic=~\"$kafka_topic\",topic!=\"\",statefulset_kubernetes_io_pod_name=~\"$strimzi_cluster_name-kafka-$kafka_broker\"}[1m]))",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -299,7 +299,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(irate(kafka_server_brokertopicmetrics_messages_in_total{topic=~\"$kafka_topic\",topic!=\"\",statefulset_kubernetes_io_pod_name=~\"$kafka_broker-kafka-[0-9]+\"}[1m]))",
+          "expr": "sum(irate(kafka_server_brokertopicmetrics_messages_in_total{topic=~\"$kafka_topic\",topic!=\"\",statefulset_kubernetes_io_pod_name=~\"$strimzi_cluster_name-kafka-$kafka_broker\"}[1m]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -418,7 +418,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(irate(kafka_server_brokertopicmetrics_messages_in_total{topic=~\"$kafka_topic\",topic!=\"\",statefulset_kubernetes_io_pod_name=~\"$kafka_broker-kafka-[0-9]+\"}[1m]))",
+          "expr": "sum(irate(kafka_server_brokertopicmetrics_messages_in_total{topic=~\"$kafka_topic\",topic!=\"\",statefulset_kubernetes_io_pod_name=~\"$strimzi_cluster_name-kafka-$kafka_broker\"}[1m]))",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -508,7 +508,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(kafka_controller_kafkacontroller_offline_partitions_count{statefulset_kubernetes_io_pod_name=~\"$kafka_broker-kafka-[0-9]+\"})",
+          "expr": "sum(kafka_controller_kafkacontroller_offline_partitions_count{statefulset_kubernetes_io_pod_name=~\"$strimzi_cluster_name-kafka-$kafka_broker\"})",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -584,7 +584,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(irate(kafka_server_brokertopicmetrics_bytes_in_total{topic=~\"$kafka_topic\",topic!=\"\",statefulset_kubernetes_io_pod_name=~\"$kafka_broker-kafka-[0-9]+\"}[1m]))",
+          "expr": "sum(irate(kafka_server_brokertopicmetrics_bytes_in_total{topic=~\"$kafka_topic\",topic!=\"\",statefulset_kubernetes_io_pod_name=~\"$strimzi_cluster_name-kafka-$kafka_broker\"}[1m]))",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -595,7 +595,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(irate(kafka_server_brokertopicmetrics_bytes_out_total{topic=~\"$kafka_topic\",topic!=\"\",statefulset_kubernetes_io_pod_name=~\"$kafka_broker-kafka-[0-9]+\"}[1m]))",
+          "expr": "sum(irate(kafka_server_brokertopicmetrics_bytes_out_total{topic=~\"$kafka_topic\",topic!=\"\",statefulset_kubernetes_io_pod_name=~\"$strimzi_cluster_name-kafka-$kafka_broker\"}[1m]))",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -698,7 +698,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "kubelet_volume_stats_available_bytes{persistentvolumeclaim=~\"data(-[0-9]+)?-$kafka_broker-kafka-[0-9]+\"}",
+          "expr": "kubelet_volume_stats_available_bytes{persistentvolumeclaim=~\"data(-[0-9]+)?-$strimzi_cluster_name-kafka-$kafka_broker\"}",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -818,7 +818,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(kafka_controller_kafkacontroller_global_partition_count)",
+          "expr": "sum(kafka_controller_kafkacontroller_global_partition_count{strimzi_io_cluster=\"$strimzi_cluster_name\"})",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -991,7 +991,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "kubelet_volume_stats_used_bytes{persistentvolumeclaim=~\"data(-[0-9]+)?-$kafka_broker-kafka-[0-9]+\"}",
+          "expr": "kubelet_volume_stats_used_bytes{persistentvolumeclaim=~\"data(-[0-9]+)?-$strimzi_cluster_name-kafka-$kafka_broker\"}",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -1001,7 +1001,7 @@
         },
         {
           "exemplar": true,
-          "expr": "kafka_broker_quota_softlimitbytes{statefulset_kubernetes_io_pod_name=~\"$kafka_broker-kafka-[0-9]+\"}",
+          "expr": "kafka_broker_quota_softlimitbytes{statefulset_kubernetes_io_pod_name=~\"$strimzi_cluster_name-kafka-$kafka_broker\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "Limit {{statefulset_kubernetes_io_pod_name}}",
@@ -1061,6 +1061,27 @@
   ],
   "templating": {
     "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
       {
         "allValue": null,
         "current": {},

--- a/rhosak.json
+++ b/rhosak.json
@@ -889,12 +889,12 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "kafka_topic:kafka_log_log_size:sum",
+          "expr": "kas_topic_partition_log_size_bytes{strimzi_io_cluster=~\"$strimzi_cluster_name\",broker_id=\"$kafka_broker\",topic_name=~\"$kafka_topic\",partition_id=~\"$kafka_partition\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{topic}}:{{partition}}",
+          "legendFormat": "{{topic_name}}:{{partition_id}}",
           "refId": "A"
         }
       ],

--- a/rhosak.json
+++ b/rhosak.json
@@ -30,8 +30,8 @@
     },
     {
       "type": "panel",
-      "id": "singlestat",
-      "name": "Singlestat",
+      "id": "stat",
+      "name": "Stat",
       "version": ""
     }
   ],
@@ -71,26 +71,42 @@
     },
     {
       "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": true,
-      "colors": [
-        "#d44a3a",
-        "rgba(237, 129, 40, 0.89)",
-        "#299c46"
-      ],
       "datasource": "${DS_PROMETHEUS}",
       "description": "Total incoming byte rate",
       "fieldConfig": {
-        "defaults": {},
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "0",
+              "type": 1,
+              "value": "null"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#d44a3a",
+                "value": null
+              },
+              {
+                "color": "rgba(237, 129, 40, 0.89)",
+                "value": 0
+              },
+              {
+                "color": "#299c46",
+                "value": 2
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
         "overrides": []
-      },
-      "format": "Bps",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
       },
       "gridPos": {
         "h": 5,
@@ -101,39 +117,24 @@
       "id": 98,
       "interval": null,
       "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
       "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "0",
-          "to": "null"
-        }
-      ],
-      "repeatDirection": "h",
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
       },
-      "tableColumn": "",
+      "pluginVersion": "7.5.17",
+      "repeatDirection": "h",
       "targets": [
         {
           "exemplar": true,
@@ -146,41 +147,47 @@
           "refId": "A"
         }
       ],
-      "thresholds": "0,2",
       "title": "Total Incoming Byte Rate",
-      "type": "singlestat",
-      "valueFontSize": "200%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "0",
-          "value": "null"
-        }
-      ],
-      "valueName": "current"
+      "type": "stat"
     },
     {
       "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": true,
-      "colors": [
-        "#d44a3a",
-        "rgba(237, 129, 40, 0.89)",
-        "#299c46"
-      ],
       "datasource": "${DS_PROMETHEUS}",
       "description": "Total outgoing byte rate",
       "fieldConfig": {
-        "defaults": {},
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "0",
+              "type": 1,
+              "value": "null"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#d44a3a",
+                "value": null
+              },
+              {
+                "color": "rgba(237, 129, 40, 0.89)",
+                "value": 0
+              },
+              {
+                "color": "#299c46",
+                "value": 2
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
         "overrides": []
-      },
-      "format": "Bps",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
       },
       "gridPos": {
         "h": 5,
@@ -191,39 +198,24 @@
       "id": 99,
       "interval": null,
       "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
       "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "repeatDirection": "h",
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
       },
-      "tableColumn": "",
+      "pluginVersion": "7.5.17",
+      "repeatDirection": "h",
       "targets": [
         {
           "exemplar": true,
@@ -236,18 +228,8 @@
           "refId": "A"
         }
       ],
-      "thresholds": "0,2",
       "title": "Total Outgoing Byte Rate",
-      "type": "singlestat",
-      "valueFontSize": "200%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "0",
-          "value": "null"
-        }
-      ],
-      "valueName": "current"
+      "type": "stat"
     },
     {
       "aliasColors": {},
@@ -352,26 +334,42 @@
     },
     {
       "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": true,
-      "colors": [
-        "#d44a3a",
-        "rgba(237, 129, 40, 0.89)",
-        "#299c46"
-      ],
       "datasource": "${DS_PROMETHEUS}",
       "description": "Incoming messages rate",
       "fieldConfig": {
-        "defaults": {},
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "0",
+              "type": 1,
+              "value": "null"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#d44a3a",
+                "value": null
+              },
+              {
+                "color": "rgba(237, 129, 40, 0.89)",
+                "value": 0
+              },
+              {
+                "color": "#299c46",
+                "value": 2
+              }
+            ]
+          },
+          "unit": "wps"
+        },
         "overrides": []
-      },
-      "format": "wps",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
       },
       "gridPos": {
         "h": 6,
@@ -382,39 +380,24 @@
       "id": 100,
       "interval": null,
       "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
       "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "repeatDirection": "h",
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
       },
-      "tableColumn": "",
+      "pluginVersion": "7.5.17",
+      "repeatDirection": "h",
       "targets": [
         {
           "exemplar": true,
@@ -427,41 +410,47 @@
           "refId": "A"
         }
       ],
-      "thresholds": "0,2",
       "title": "Incoming Messages Rate",
-      "type": "singlestat",
-      "valueFontSize": "200%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "0",
-          "value": "null"
-        }
-      ],
-      "valueName": "current"
+      "type": "stat"
     },
     {
       "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": true,
-      "colors": [
-        "#d44a3a",
-        "rgba(237, 129, 40, 0.89)",
-        "#299c46"
-      ],
       "datasource": "${DS_PROMETHEUS}",
       "description": "Total partitions offline",
       "fieldConfig": {
-        "defaults": {},
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "0",
+              "type": 1,
+              "value": "null"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#d44a3a",
+                "value": null
+              },
+              {
+                "color": "rgba(237, 129, 40, 0.89)",
+                "value": 0
+              },
+              {
+                "color": "#299c46",
+                "value": 2
+              }
+            ]
+          },
+          "unit": "none"
+        },
         "overrides": []
-      },
-      "format": "none",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
       },
       "gridPos": {
         "h": 6,
@@ -472,39 +461,24 @@
       "id": 110,
       "interval": null,
       "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
       "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "repeatDirection": "h",
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
       },
-      "tableColumn": "",
+      "pluginVersion": "7.5.17",
+      "repeatDirection": "h",
       "targets": [
         {
           "exemplar": true,
@@ -517,18 +491,8 @@
           "refId": "A"
         }
       ],
-      "thresholds": "0,2",
       "title": "Offline Partitions Count",
-      "type": "singlestat",
-      "valueFontSize": "200%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "0",
-          "value": "null"
-        }
-      ],
-      "valueName": "current"
+      "type": "stat"
     },
     {
       "aliasColors": {},
@@ -752,26 +716,42 @@
     },
     {
       "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": true,
-      "colors": [
-        "#d44a3a",
-        "rgba(237, 129, 40, 0.89)",
-        "#299c46"
-      ],
       "datasource": "${DS_PROMETHEUS}",
       "description": "Total partitions offline",
       "fieldConfig": {
-        "defaults": {},
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "0",
+              "type": 1,
+              "value": "null"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#d44a3a",
+                "value": null
+              },
+              {
+                "color": "rgba(237, 129, 40, 0.89)",
+                "value": 0
+              },
+              {
+                "color": "#299c46",
+                "value": 2
+              }
+            ]
+          },
+          "unit": "none"
+        },
         "overrides": []
-      },
-      "format": "none",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
       },
       "gridPos": {
         "h": 7,
@@ -782,39 +762,24 @@
       "id": 111,
       "interval": null,
       "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
       "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "repeatDirection": "h",
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
       },
-      "tableColumn": "",
+      "pluginVersion": "7.5.17",
+      "repeatDirection": "h",
       "targets": [
         {
           "exemplar": true,
@@ -827,18 +792,8 @@
           "refId": "A"
         }
       ],
-      "thresholds": "0,2",
       "title": "Global Partition Count",
-      "type": "singlestat",
-      "valueFontSize": "200%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "0",
-          "value": "null"
-        }
-      ],
-      "valueName": "current"
+      "type": "stat"
     },
     {
       "aliasColors": {},

--- a/rhosak.json
+++ b/rhosak.json
@@ -14,7 +14,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "7.5.11"
+      "version": "7.5.17"
     },
     {
       "type": "panel",
@@ -52,7 +52,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1637171817491,
+  "iteration": 1678737515310,
   "links": [],
   "panels": [
     {
@@ -270,7 +270,7 @@
       },
       "paceLength": 10,
       "percentage": false,
-      "pluginVersion": "7.5.11",
+      "pluginVersion": "7.5.17",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -309,7 +309,6 @@
       },
       "yaxes": [
         {
-          "$$hashKey": "object:758",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -318,7 +317,6 @@
           "show": true
         },
         {
-          "$$hashKey": "object:759",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -537,7 +535,7 @@
       },
       "paceLength": 10,
       "percentage": false,
-      "pluginVersion": "7.5.11",
+      "pluginVersion": "7.5.17",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -588,7 +586,6 @@
       },
       "yaxes": [
         {
-          "$$hashKey": "object:909",
           "decimals": null,
           "format": "bytes",
           "label": "",
@@ -598,7 +595,6 @@
           "show": true
         },
         {
-          "$$hashKey": "object:910",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -651,7 +647,7 @@
       },
       "paceLength": 10,
       "percentage": false,
-      "pluginVersion": "7.5.11",
+      "pluginVersion": "7.5.17",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -691,7 +687,6 @@
       },
       "yaxes": [
         {
-          "$$hashKey": "object:346",
           "format": "bytes",
           "label": null,
           "logBase": 1,
@@ -700,7 +695,6 @@
           "show": true
         },
         {
-          "$$hashKey": "object:347",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -833,7 +827,7 @@
       },
       "paceLength": 10,
       "percentage": false,
-      "pluginVersion": "7.5.11",
+      "pluginVersion": "7.5.17",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -873,7 +867,6 @@
       },
       "yaxes": [
         {
-          "$$hashKey": "object:187",
           "format": "bytes",
           "label": null,
           "logBase": 1,
@@ -882,7 +875,6 @@
           "show": true
         },
         {
-          "$$hashKey": "object:188",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -935,7 +927,7 @@
       },
       "paceLength": 10,
       "percentage": false,
-      "pluginVersion": "7.5.11",
+      "pluginVersion": "7.5.17",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -983,7 +975,6 @@
       },
       "yaxes": [
         {
-          "$$hashKey": "object:346",
           "format": "bytes",
           "label": null,
           "logBase": 1,
@@ -992,7 +983,6 @@
           "show": true
         },
         {
-          "$$hashKey": "object:347",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -1179,5 +1169,5 @@
   "timezone": "",
   "title": "Red Hat OpenShift Streams for Apache Kafka",
   "uid": "86cc98e66c294b299b37102f0cc74ead",
-  "version": 8
+  "version": 10
 }


### PR DESCRIPTION
The original intention was clearly to display like this, but it's only more recently that it became available through the kas-fleet-manager API.

This change also fixes the dashboard variables and some broken panel queries, and migrates off deprecated panel types to the modern equivalents.

Before:
![image](https://user-images.githubusercontent.com/442386/224826652-f12de289-bc64-4b15-aa83-2bdd4f2113b5.png)

After:
![image](https://user-images.githubusercontent.com/442386/226986007-2841a9a9-7b4e-4ea4-835e-74e7c2724f98.png)

